### PR TITLE
fix: correct typos in log messages and error strings

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 			fmt.Println(err)
 			os.Exit(1)
 		}
-		fmt.Println("connection accepeted: ", conn.RemoteAddr())
+		fmt.Println("connection accepted: ", conn.RemoteAddr())
 
 		go func() {
 			handleConn(conn, state)
@@ -60,7 +60,7 @@ func main() {
 }
 
 func handleConn(conn net.Conn, state *AppState) {
-	log.Println("accepeted new connection: ", conn.LocalAddr().String())
+	log.Println("accepted new connection: ", conn.LocalAddr().String())
 	c := NewClient(conn)
 	rd := bufio.NewReader(conn)
 	for {

--- a/resp.go
+++ b/resp.go
@@ -57,7 +57,7 @@ func (r *Resp) parseRespArr(rd *bufio.Reader) error {
 		return err
 	}
 	if line[0] != '*' {
-		return errors.New("expcted array")
+		return errors.New("expected array")
 	}
 
 	arrLen, err := strconv.Atoi(line[1:])

--- a/writer.go
+++ b/writer.go
@@ -35,7 +35,7 @@ func (w *Writer) Deserialize(r *Resp) (reply string) {
 	case Null:
 		reply = "$-1\r\n"
 	default:
-		log.Println("invalid typ received")
+		log.Println("invalid type received")
 		return reply
 	}
 	return reply


### PR DESCRIPTION
## Summary
Fixes 3 typos reported in issue #18:
- `main.go`: `accepeted` → `accepted` (2 occurrences in log messages)
- `resp.go`: `expcted` → `expected` (error string)
- `writer.go`: `typ` → `type` (log message)

## Changes
- 3 files, 4 line changes (string replacements only, no behavior change)
- Verified: Go syntax check passed (trivial string changes)

Closes #18